### PR TITLE
add version attribute to chef_server_ingredient install action

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,3 +16,11 @@ suites:
       - recipe[test]
       - recipe[chef-server-ingredient]
     attributes:
+  - name: override_package_versions
+    run_list:
+      - recipe[test]
+      - recipe[chef-server-ingredient]
+    attributes:
+      test:
+        chef-server-core:
+          version: 12.0.0-rc.5-1

--- a/libraries/chef_server_ingredients_provider.rb
+++ b/libraries/chef_server_ingredients_provider.rb
@@ -45,6 +45,7 @@ class Chef
 
         package new_resource.package_name do
           options new_resource.options
+          version new_resource.version
         end
       end
 

--- a/libraries/chef_server_ingredients_resource.rb
+++ b/libraries/chef_server_ingredients_resource.rb
@@ -15,6 +15,7 @@ class Chef
       # Attributes for packagecloud/apt repository
       attribute :master_token, :kind_of => String
       attribute :repository, :kind_of => String, :default => 'chef/stable'
+      attribute :version, :kind_of => String, :default => nil
     end
   end
 end

--- a/test/fixtures/cookbooks/test/attributes/default.rb
+++ b/test/fixtures/cookbooks/test/attributes/default.rb
@@ -1,0 +1,1 @@
+default['test']['chef-server-core']['version'] = nil

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -9,6 +9,7 @@ execute 'apt-get update' if platform_family?('debian')
 
 chef_server_ingredient 'chef-server-core' do
   action [:install, :reconfigure]
+  version node['test']['chef-server-core']['version']
 end
 
 chef_server_ingredient 'opscode-manage' do

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -6,7 +6,7 @@ describe 'chef-server-ingredient::default' do
   end
 
   describe command('chef-server-ctl test') do
-    it { should return_exit_status 0 }
+    its(:exit_status) { should eq 0 }
   end
 
   describe package('opscode-manage') do
@@ -14,6 +14,6 @@ describe 'chef-server-ingredient::default' do
   end
 
   describe command('opscode-manage-ctl test') do
-    it { should return_exit_status 0 }
+    its(:exit_status) { should eq 0 }
   end
 end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,5 +1,3 @@
 require 'serverspec'
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
-include Serverspec::Helper::Properties
+set :backend, :exec

--- a/test/integration/override_package_versions/serverspec/assert_package_version_installed_spec.rb
+++ b/test/integration/override_package_versions/serverspec/assert_package_version_installed_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'chef-server-ingredient::default' do
+  describe package('chef-server-core') do
+    it { should be_installed.with_version('12.0.0-rc.5-1') }
+  end
+end

--- a/test/integration/override_package_versions/serverspec/spec_helper.rb
+++ b/test/integration/override_package_versions/serverspec/spec_helper.rb
@@ -1,0 +1,1 @@
+../../default/serverspec/spec_helper.rb


### PR DESCRIPTION
package version attributes defaults to `nil` like the chef package resource

updated serverspec to work with latest version

added kitchen test suite to test the installation of a specified version
updated default_spec instead of creating a new spec
a) verify when version attribute is not specified (manage)
b) verify when version attribute is nil the package resource preserves default behavior
c) verify specified version attribute 

Things I'd like to improve:
- setting of version override attribute (currently set in .kitchen.yml and spec)
- optimize shared use of spec_helper.rb

This change works with qa-chef-server-cluster (specifying a version attribute and omitting it)
