### PR TITLE
Update test to an actual released version

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -29,4 +29,4 @@ suites:
     attributes:
       test:
         chef-server-core:
-          version: 12.0.0-rc.5-1
+          version: 12.0.4-1

--- a/test/integration/override_package_versions/serverspec/assert_package_version_installed_spec.rb
+++ b/test/integration/override_package_versions/serverspec/assert_package_version_installed_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe 'chef-server-ingredient::default' do
   describe package('chef-server-core') do
-    it { should be_installed.with_version('12.0.0-rc.5-1') }
+    it { should be_installed.with_version('12.0.4-1') }
   end
 end


### PR DESCRIPTION
This PR just updates the tests to use a recent release as opposed to the release-candidate (which was failing for me). Also makes explicit the need for the patch level on releases.